### PR TITLE
[FIX] User popups

### DIFF
--- a/_includes/people/alumni.html
+++ b/_includes/people/alumni.html
@@ -5,8 +5,9 @@
   {% tablerow person in alumni cols:2 %}
   <!-- Set person image -->
   {% assign image = "/assets/images/people/placeholder.png" %} {% for
-    static_file in site.static_files %} {% if person.image == static_file.path %}
-    {% assign image = person.image %} {% endif %} {% endfor %}
+  static_file in site.static_files %} {% if person.image == static_file.path %}
+  {% assign image = person.image %} {% endif %} {% endfor %}
+  {% assign person-id = person.name | replace: " ", "-" %}
     
   <!-- Person's mini profile -->
   <div class="d-flex">

--- a/_includes/people/current.html
+++ b/_includes/people/current.html
@@ -7,6 +7,7 @@
   {% assign image = "/assets/images/people/placeholder.png" %} {% for
   static_file in site.static_files %} {% if person.image == static_file.path %}
   {% assign image = person.image %} {% endif %} {% endfor %}
+  {% assign person-id = person.name | replace: " ", "-" %}
 
   <!-- Person's mini profile -->
   <div class="d-flex">


### PR DESCRIPTION
Just noticed that the user pop-up bio's weren't working properly. This broke when I introduced code to always use a placeholder image if no uploaded image found. This PR fixes this by re-implementing the following:

* Add "person-id" back into the code so each user has a unique id associated with their pop up profile