### PR TITLE
Fix publications workflow add quotes around matrix versions

### DIFF
--- a/.github/workflows/grab_articles.yml
+++ b/.github/workflows/grab_articles.yml
@@ -12,25 +12,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
-        poetry-version: [1.2.2]
+        python-version: ['3.10']
+        poetry-version: ['1.2.2']
 
     steps:
       - name: Checkout master branch
         uses: actions/checkout@master
 
       - name: Select Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Poetry ${{ matrix.poetry-version }}
-        uses: Gr1N/setup-poetry@v7
+        uses: Gr1N/setup-poetry@v8
         with: 
           poetry-version: ${{ matrix.poetry-version }}
 
       - name: Check cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: ~/.cache/pypoetry/virtualenvs
@@ -59,7 +59,7 @@ jobs:
 
       # Creates a PR for review if new article(s) found
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         if: steps.article-condition.outputs.hit == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -82,5 +82,5 @@ jobs:
         uses: ad-m/github-push-action@master
         if: steps.article-condition.outputs.hit != 'true'
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Proposed changes

Python version was being incorrectly grabbed (`3.1`). This fixes it by adding quotes around the versions used in the strategy matrix. 

Additionally updates the versions used in workflow dependencies.