### PR TITLE
Add empty dev group to fix workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ jupyter = "^1.0"
 pandas = "^1.2"
 papermill = "~2.3"
 
+[tool.poetry.group.dev.dependencies]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Proposed changes

Workflow currently failing as it tries to with `--with dev` which no longer exists as a group. The workflow, as is, does not allow for an install option without this. Until this is fixed, adding an empty `dev` dependencies group.